### PR TITLE
collect dependencies in requirements.txt for easy installation with pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ networkx          1.11
 joblib            0.13.0
 logging           0.4.9.6  
 ```
+Install them by running `pip3 install -r requirements.txt` from the project root.
 
 ### Datasets
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+jsonschema==2.6.0
+tqdm==4.28.1
+numpy==1.15.4
+pandas==0.23.4
+texttable==1.5.0
+gensim==3.6.0
+networkx==1.11
+joblib==0.13.0


### PR DESCRIPTION
Having all dependencies (except logging, it's in stdlib) in one file allows very easy installation with
```
pip3 install -r requirements.txt
```