### PR TITLE
Fix dataset reader for graphs with no node features

### DIFF
--- a/src/graph2vec.py
+++ b/src/graph2vec.py
@@ -71,10 +71,11 @@ def dataset_reader(path):
 
     if "features" in data.keys():
         features = data["features"]
+        features = {int(k): v for k, v in features.items()}
     else:
         features = nx.degree(graph)
-
-    features = {int(k): v for k, v in features.items()}
+        features = {int(k): v for k, v in features}
+       
     return graph, features, name
 
 def feature_extractor(path, rounds):


### PR DESCRIPTION
### Reference Issues/PR
#37 input JSON

### what does this implement/fix? Explain your changes
The degree function used when there are no features in nodes returns a list, not a tuple.
 so I have made the required changes to fix that issue by simply updating the features in the conditional statements themselves. 